### PR TITLE
Adds sensor i2c address setting into init() method. 

### DIFF
--- a/DFRobot_LIS2DH12.cpp
+++ b/DFRobot_LIS2DH12.cpp
@@ -14,11 +14,10 @@
 #include <DFRobot_LIS2DH12.h>
 #include <Wire.h>
 
-uint8_t DFRobot_LIS2DH12::sensorAddress = 0x18; //	0x18
-
-int8_t DFRobot_LIS2DH12::init(uint8_t range)
+int8_t DFRobot_LIS2DH12::init(uint8_t range, uint8_t sensorAddress)
 {
     int8_t ret = 0;
+    this->sensorAddress = sensorAddress;
     
     setRange(range);
     Wire.beginTransmission(sensorAddress);

--- a/DFRobot_LIS2DH12.h
+++ b/DFRobot_LIS2DH12.h
@@ -25,8 +25,7 @@
 
 class DFRobot_LIS2DH12 {
 public:
-	static uint8_t sensorAddress; ///< IIC address of the sensor
-	int8_t init(uint8_t range); ///< Initialization function
+	int8_t init(uint8_t range, uint8_t sensorAddress = 0x18); ///< Initialization function
 	void readXYZ(int16_t&, int16_t&, int16_t&); ///< read x, y, z data
 	void mgScale(int16_t&, int16_t&, int16_t&); ///< transform data to millig
   /*!
@@ -54,5 +53,6 @@ private:
 	
 	uint8_t mgPerDigit;
 	uint8_t  mgScaleVel;
+	uint8_t sensorAddress; ///< IIC address of the sensor
 };	
 #endif


### PR DESCRIPTION
I made these changes to enable the use of a sensor at a different address (it can be set to 0x19 by the pin SA0). I put the address as a private attribute because it doesn't make sense to change it outside of initialization.
I also removed the static attribute of i2c address to enable the use of multiple sensors with different addresses.